### PR TITLE
Change deprecated item_includes method to item_associations

### DIFF
--- a/lib/administrate_ransack/searchable.rb
+++ b/lib/administrate_ransack/searchable.rb
@@ -9,9 +9,9 @@ module AdministrateRansack
       @ransack_results.result(distinct: true)
     end
 
-    # ref => https://github.com/thoughtbot/administrate/blob/v0.15.0/app/helpers/administrate/application_helper.rb#L54-L60
+    # ref => https://github.com/thoughtbot/administrate/blob/v0.18.0/app/helpers/administrate/application_helper.rb#L72-L78
     def sanitized_order_params(page, current_field_name)
-      collection_names = page.item_includes + [current_field_name]
+      collection_names = page.item_associations + [current_field_name]
       association_params = collection_names.map do |assoc_name|
         { assoc_name => %i[order direction page per_page] }
       end


### PR DESCRIPTION
Administrate deprecated `item_includes` in favor of `item_associations` in v0.18.0 https://github.com/thoughtbot/administrate/commit/2b6813035bbdfd5ab04a07b6bc5ba653da88010c

This change updates the `sanitized_order_params` method in `Searchable` to remove the deprecation warning. 