### PR TITLE
Update ransack dependency and add actionpack and actionview gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ group :development, :test do
   gem 'appraisal'
   gem 'puma'
   gem 'sqlite3'
+  gem 'actionpack', '~> 7.0.0'
+  gem 'actionview', '~> 7.0.0'
 
   # Testing
   gem 'capybara'

--- a/administrate_ransack.gemspec
+++ b/administrate_ransack.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir['{app,config,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   spec.add_runtime_dependency 'administrate', '~> 0.18'
-  spec.add_runtime_dependency 'ransack', '~> 2.3'
+  spec.add_runtime_dependency 'ransack', '~> 3.0'
 end


### PR DESCRIPTION
The `ransack` gem dependency has been updated from version 2.3 or greater to version 3.0 or greater due to new composite predicates features introduced in version 3.0 which improves searching. Also, added `actionpack` and `actionview` gems with version 7.0.0 or greater to leverage the latest features and improvements from Rails 7 for better web requests handling and template rendering. All the changes should provide performance improvements, and better compatibility with up-to-date Rails projects.