### PR TITLE
Add invalid search term handling

### DIFF
--- a/lib/administrate_ransack/searchable.rb
+++ b/lib/administrate_ransack/searchable.rb
@@ -6,7 +6,13 @@ module AdministrateRansack
   module Searchable
     def scoped_resource
       options = respond_to?(:ransack_options) ? ransack_options : {}
-      @ransack_results = super.ransack(params[:q], **options)
+      begin
+        @ransack_results = super.ransack(params[:q], **options)
+      rescue ArgumentError => e
+        handle_ransack_argument_error(e)
+        set_flash_message_as_ransack_argument_error(e)
+        @ransack_results = reset_ransack_result_on_error(super).ransack({}, **options)
+      end
       @ransack_results.result(distinct: true)
     end
 
@@ -23,6 +29,33 @@ module AdministrateRansack
       def prepended(base)
         base.helper_method :sanitized_order_params
       end
+    end
+
+    private
+
+    def set_flash_message_as_ransack_argument_error(error)
+      if error.message.eql?("Invalid sorting parameter provided")
+        flash.now[:alert] = I18n.t(
+          :invalid_sorting_parameter_provided,
+          scope: [:administrate_ransack, :errors],
+          default: error.message
+        )
+      elsif error.message.start_with?("Invalid search term ")
+        flash.now[:alert] = I18n.t(
+          :invalid_search_term,
+          search_term: error.message.split(' ')[3..].join(' '),
+          scope: [:administrate_ransack, :errors],
+          default: error.message
+        )
+      end
+    end
+
+    def handle_ransack_argument_error(error)
+      super if defined?(super)
+    end
+
+    def reset_ransack_result_on_error(super_scoped_resource)
+      super_scoped_resource.none
     end
   end
 end

--- a/spec/controllers/admin/posts_controller_spec.rb
+++ b/spec/controllers/admin/posts_controller_spec.rb
@@ -9,10 +9,43 @@ RSpec.describe Admin::PostsController do
     end
 
     context "when ransack_options is defined" do
-      it "raises an exception with an invalid parameter" do
-        expect {
+      context "when you want to handle the error manualy" do
+        controller do
+          def handle_ransack_argument_error(error)
+            raise error
+          end
+        end
+
+        it "raises an exception with an invalid parameter" do
+          expect {
+            get :index, params: { "q[title2_cont]" => "test" }
+          }.to raise_exception(ArgumentError, 'Invalid search term title2_cont')
+        end
+      end
+
+      context "when you want to reset the ransack result and display a flash message on error" do
+        it "resets the ransack result and displays a flash message" do
           get :index, params: { "q[title2_cont]" => "test" }
-        }.to raise_exception(ArgumentError, 'Invalid search term title2_cont')
+
+          expect(assigns(:ransack_results)).to be_instance_of Ransack::Search
+          expect(assigns(:ransack_results).result).to be_empty
+          expect(flash[:alert]).to eq 'Invalid search term title2_cont'
+        end
+      end
+
+      context "when you want to not reset the ransack result on error" do
+        controller do
+          def reset_ransack_result_on_error(super_scoped_resource)
+            super_scoped_resource
+          end
+        end
+
+        it "does not reset the ransack result" do
+          get :index, params: { "q[title2_cont]" => "test" }
+
+          expect(assigns(:ransack_results)).to be_instance_of Ransack::Search
+          expect(assigns(:ransack_results).result).to_not be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
For security reasons, I would like to display a warning and reset the search results when invalid search parameters are included. What do you think?
I have divided it into several methods, so it can also function as it did previously.

Due to weak error handling on the Ransack side, it currently extracts the message from an `ArgumentError`. This issue seems to be under discussion on the Ransack side, so it might be handled by a dedicated error class in the future.
https://github.com/activerecord-hackery/ransack/pull/1478

This is my sample application.
![image](https://github.com/user-attachments/assets/83e68d58-b8a8-4fed-a6eb-f8121d0bd390)

