### PR TITLE
Fix Ransack version check for allowlisting attributes and associations

### DIFF
--- a/spec/dummy/app/models/application_record.rb
+++ b/spec/dummy/app/models/application_record.rb
@@ -8,7 +8,7 @@ class ApplicationRecord < ActiveRecord::Base
   scope :published, -> {}
 
   class << self
-    if Gem::Version.new(Ransack::VERSION) >= Gem::Version.new("4.1.1")
+    if Gem::Version.new(Ransack::VERSION) >= Gem::Version.new("4.0.0")
       def ransackable_attributes(auth_object = nil)
         authorizable_ransackable_attributes
       end


### PR DESCRIPTION
Apologies, the previous fix (#27) added to the demo application was incorrect. 

The `ransackable_attributes` and `ransackable_associations` allowlisting were introduced in Ransack 4.0.0, not 4.1.1. As a result, the demo application specifying Ransack 4.0.0 encountered errors. 

https://github.com/activerecord-hackery/ransack/releases/tag/v4.0.0
https://github.com/activerecord-hackery/ransack/pull/1400/files

This PR corrects the version check to properly handle the allowlisting introduced in Ransack 4.0.0.

